### PR TITLE
Attempt to enforce "additionalProperties" to false

### DIFF
--- a/src/main/resources/examples/resource/initech.tps.report.v1.json
+++ b/src/main/resources/examples/resource/initech.tps.report.v1.json
@@ -17,7 +17,8 @@
                 "Body": {
                     "type": "string"
                 }
-            }
+            },
+            "additionalProperties": false
         }
     },
     "properties": {
@@ -99,5 +100,6 @@
                 "initech:ListReports"
             ]
         }
-    }
+    },
+    "additionalProperties": false
 }

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -62,6 +62,19 @@
                         ]
                     }
                 }
+            },
+            "if": {
+                "$comment": "All properties of a resource must be expressed in the schema - arbitrary inputs are not allowed",
+                "properties": {
+                    "type": {
+                        "const": "object"
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "additionalProperties"
+                ]
             }
         },
         "properties": {
@@ -70,7 +83,7 @@
                     "$ref": "#/definitions/validations"
                 },
                 {
-                    "$comment": "The following subset of draft-07 property references is supported for resource definitions. Nested properties are disallowed and should be specified as a $ref to a definitions block.",
+                    "$comment": "The following subset of draft-07 property references is supported for resource definitions.",
                     "type": "object",
                     "properties": {
                         "insertionOrder": {

--- a/src/test/java/com/amazonaws/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -29,7 +29,8 @@ public class ResourceTypeSchemaTest {
     private static final String TEST_SCHEMA_PATH = "/test-schema.json";
     private static final String EMPTY_SCHEMA_PATH = "/empty-schema.json";
     private static final String MINIMAL_SCHEMA_PATH = "/minimal-schema.json";
-    private static final String NO_ADDITIONAL_PROPERTIES_SCHEMA_PATH = "/no-additional-properties-schema.json";
+    private static final String NO_ADDITIONAL_PROPERTIES_TOP_LEVEL_PATH = "/no-additional-properties-top-level.json";
+    private static final String NO_ADDITIONAL_PROPERTIES_PROP_LEVEL_PATH = "/no-additional-properties-prop-level.json";
 
     @Test
     public void getProperties() {
@@ -107,11 +108,21 @@ public class ResourceTypeSchemaTest {
     }
 
     @Test
-    public void invalidSchema_noAdditionalProperties_shouldThrow() {
-        JSONObject o = new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(NO_ADDITIONAL_PROPERTIES_SCHEMA_PATH)));
+    public void invalidSchema_noAdditionalPropertiesTopLevel_shouldThrow() {
+        JSONObject o = new JSONObject(new JSONTokener(this.getClass()
+            .getResourceAsStream(NO_ADDITIONAL_PROPERTIES_TOP_LEVEL_PATH)));
 
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> ResourceTypeSchema.load(o)).withNoCause()
             .withMessage("#: required key [additionalProperties] not found");
+    }
+
+    @Test
+    public void invalidSchema_noAdditionalPropertiesPropLevel_shouldThrow() {
+        JSONObject o = new JSONObject(new JSONTokener(this.getClass()
+            .getResourceAsStream(NO_ADDITIONAL_PROPERTIES_PROP_LEVEL_PATH)));
+
+        assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> ResourceTypeSchema.load(o)).withNoCause()
+            .withMessage("#/properties/propertyA: #: only 1 subschema matches out of 2");
     }
 
     @Test

--- a/src/test/java/com/amazonaws/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/resource/ValidatorTest.java
@@ -276,7 +276,8 @@ public class ValidatorTest {
     public void validateDefinition_validMinimalDefinition_shouldNotThrow() {
         final JSONObject definition = new JSONObject().put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
             .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION).put(PRIMARY_IDENTIFIER_KEY, Arrays.asList(EXAMPLE_PRIMARY_IDENTIFIER))
-            .put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject()))
+            .put(PROPERTIES_KEY,
+                new JSONObject().put("property", new JSONObject().put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE)))
             .put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
 
         validator.validateResourceDefinition(definition);
@@ -301,7 +302,8 @@ public class ValidatorTest {
     @Test
     public void validateDefinition_invalidDefinitionNoDescriptionKey_shouldThrow() {
         final JSONObject definition = new JSONObject().put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
-            .put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject()))
+            .put(PROPERTIES_KEY,
+                new JSONObject().put("property", new JSONObject().put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE)))
             .put(PRIMARY_IDENTIFIER_KEY, Arrays.asList(EXAMPLE_PRIMARY_IDENTIFIER))
             .put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
 
@@ -323,7 +325,9 @@ public class ValidatorTest {
     @Test
     public void validateDefinition_invalidDefinitionNoPrimaryIdentifier_shouldThrow() {
         final JSONObject definition = new JSONObject().put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
-            .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION).put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject()))
+            .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION)
+            .put(PROPERTIES_KEY,
+                new JSONObject().put("property", new JSONObject().put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE)))
             .put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
 
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
@@ -354,8 +358,9 @@ public class ValidatorTest {
     public void validateDefinition_nonMatchingDocumentationUrl_shouldThrow(final String documentationUrl) {
         final JSONObject definition = new JSONObject().put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
             .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION).put(PRIMARY_IDENTIFIER_KEY, Arrays.asList(EXAMPLE_PRIMARY_IDENTIFIER))
-            .put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject())).put("documentationUrl", documentationUrl)
-            .put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
+            .put(PROPERTIES_KEY,
+                new JSONObject().put("property", new JSONObject().put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE)))
+            .put("documentationUrl", documentationUrl).put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
 
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
             .withMessageContaining("#/documentationUrl").withMessageNotContaining(documentationUrl);
@@ -367,8 +372,9 @@ public class ValidatorTest {
     public void validateDefinition_matchingDocumentationUrl_shouldNotThrow(final String documentationUrl) {
         final JSONObject definition = new JSONObject().put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
             .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION).put(PRIMARY_IDENTIFIER_KEY, Arrays.asList(EXAMPLE_PRIMARY_IDENTIFIER))
-            .put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject())).put("documentationUrl", documentationUrl)
-            .put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
+            .put(PROPERTIES_KEY,
+                new JSONObject().put("property", new JSONObject().put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE)))
+            .put("documentationUrl", documentationUrl).put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
 
         validator.validateResourceDefinition(definition);
     }
@@ -378,8 +384,9 @@ public class ValidatorTest {
         final String documentationUrl = "https://much-too-loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.com/";
         final JSONObject definition = new JSONObject().put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
             .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION).put(PRIMARY_IDENTIFIER_KEY, Arrays.asList(EXAMPLE_PRIMARY_IDENTIFIER))
-            .put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject())).put("documentationUrl", documentationUrl)
-            .put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
+            .put(PROPERTIES_KEY,
+                new JSONObject().put("property", new JSONObject().put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE)))
+            .put("documentationUrl", documentationUrl).put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
 
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
             .withMessageContaining("#/documentationUrl").withMessageContaining(Integer.toString(documentationUrl.length()));
@@ -390,8 +397,9 @@ public class ValidatorTest {
     public void validateDefinition_nonMatchingSourceUrls_shouldThrow(final String sourceUrl) {
         final JSONObject definition = new JSONObject().put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
             .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION).put(PRIMARY_IDENTIFIER_KEY, Arrays.asList(EXAMPLE_PRIMARY_IDENTIFIER))
-            .put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject())).put("sourceUrl", sourceUrl)
-            .put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
+            .put(PROPERTIES_KEY,
+                new JSONObject().put("property", new JSONObject().put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE)))
+            .put("sourceUrl", sourceUrl).put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
 
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
             .withMessageContaining("#/sourceUrl").withMessageNotContaining((sourceUrl));
@@ -403,8 +411,9 @@ public class ValidatorTest {
     public void validateDefinition_matchingSourceUrl_shouldNotThrow(final String sourceUrl) {
         final JSONObject definition = new JSONObject().put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
             .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION).put(PRIMARY_IDENTIFIER_KEY, Arrays.asList(EXAMPLE_PRIMARY_IDENTIFIER))
-            .put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject())).put("sourceUrl", sourceUrl)
-            .put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
+            .put(PROPERTIES_KEY,
+                new JSONObject().put("property", new JSONObject().put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE)))
+            .put("sourceUrl", sourceUrl).put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
 
         validator.validateResourceDefinition(definition);
     }
@@ -414,8 +423,9 @@ public class ValidatorTest {
         final String sourceUrl = "https://much-too-loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.com/";
         final JSONObject definition = new JSONObject().put(TYPE_NAME_KEY, EXAMPLE_TYPE_NAME)
             .put(DESCRIPTION_KEY, EXAMPLE_DESCRIPTION).put(PRIMARY_IDENTIFIER_KEY, Arrays.asList(EXAMPLE_PRIMARY_IDENTIFIER))
-            .put(PROPERTIES_KEY, new JSONObject().put("property", new JSONObject())).put("sourceUrl", sourceUrl)
-            .put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
+            .put(PROPERTIES_KEY,
+                new JSONObject().put("property", new JSONObject().put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE)))
+            .put("sourceUrl", sourceUrl).put(ADDITIONAL_PROPERTIES_KEY, ADDITIONAL_PROPERTIES_VALUE);
 
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
             .withMessageContaining("#/sourceUrl").withMessageContaining(Integer.toString(sourceUrl.length()));

--- a/src/test/resources/no-additional-properties-prop-level.json
+++ b/src/test/resources/no-additional-properties-prop-level.json
@@ -1,0 +1,11 @@
+{
+    "typeName": "AWS::Test::TestModel",
+    "description": "A test schema for unit tests.",
+    "properties": {
+        "propertyA": {}
+    },
+    "primaryIdentifier": [
+        "/properties/PropertyA"
+    ],
+    "additionalProperties": false
+}

--- a/src/test/resources/no-additional-properties-top-level.json
+++ b/src/test/resources/no-additional-properties-top-level.json
@@ -1,0 +1,12 @@
+{
+    "typeName": "AWS::Test::TestModel",
+    "description": "A test schema for unit tests.",
+    "properties": {
+        "propertyA": {
+            "type": "boolean"
+        }
+    },
+    "primaryIdentifier": [
+        "/properties/PropertyA"
+    ]
+}

--- a/src/test/resources/test-schema.json
+++ b/src/test/resources/test-schema.json
@@ -17,6 +17,9 @@
         },
         "propertyD": {
             "type": "boolean"
+        },
+        "propertyE": {
+            "additionalProperties": false
         }
     },
     "required": [


### PR DESCRIPTION
*Issue #, if available:* #33

*Description of changes:* Require `additionalProperties` for objects. This does work, but also causes `$ref` to require `"additionalProperties": false`, as definitions without a `type` are implicitly `object`. Since we are not resolving refs as a language feature, but validating it as is, they implicitly default to it (#23). Hence, draft.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
