### PR TITLE
Allow use of $id keyword in resource schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ The following (truncated) example shows some of the semantic definitions for an 
 
 ```
 {
-    "$id": "aws.s3.bucket.v1.json",
+    "$id": "aws-s3-bucket.json",
     "typeName": "AWS::S3::Bucket",
     "definitions": { ... },
     "properties": {
         "Arn": {
-            "$ref": "../aws.common.types.v1.json#/definitions/Arn"
+            "$ref": "aws.common.types.v1.json#/definitions/Arn"
         },
         "BucketName": {
             "type": "string"
@@ -77,15 +77,17 @@ Relationships between resources can be expressed through the use of the `$ref` k
 
 The following example shows a property relationship between an `AWS::EC2::Subnet.VpcId` and an `AWS::EC2::VPC.Name`. The schema for the 'remote' type (`AWS::EC2::VPC`) is used to validate the content of the 'local' type (`AWS::EC2::Subnet`) and can be inferred as a dependency from the local to the remote type.
 
+Setting the $id property to a remote location will make validation framework to pull dependencies expressed using relative `$ref` URIs from the remote hosts. In this example, `VpcId` property will be verified against the schema for `AWS::EC2::VPC.Name` hosted at `https://schema.cloudformation.us-east-1.amazonaws.com/aws-ec2-vpc.json`  
+
 ```
 {
-    "$id": "aws.ec2.subnet.v1.json",
+    "$id": "https://schema.cloudformation.us-east-1.amazonaws.com/aws-ec2-subnet.json",
     "typeName": "AWS::EC2::Subnet",
     "definitions": { ... },
     "properties": {
         { ... }
         "VpcId": {
-            "$ref": "http://cloudformation.amazonaws.com/type/resource/aws/ec2/vpc/properties/Name"
+            "$ref": "aws-ec2-vpc.json#/properties/Name"
         }
     }
 }
@@ -93,7 +95,7 @@ The following example shows a property relationship between an `AWS::EC2::Subnet
 
 ```
 {
-    "$id": "aws.ec2.vpc.v1.json",
+    "$id": "https://schema.cloudformation.us-east-1.amazonaws.com/aws-ec2-vpc.json",
     "typeName": "AWS::EC2::VPC",
     "definitions": { ... },
     "properties": {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Relationships between resources can be expressed through the use of the `$ref` k
 
 The following example shows a property relationship between an `AWS::EC2::Subnet.VpcId` and an `AWS::EC2::VPC.Name`. The schema for the 'remote' type (`AWS::EC2::VPC`) is used to validate the content of the 'local' type (`AWS::EC2::Subnet`) and can be inferred as a dependency from the local to the remote type.
 
-Setting the $id property to a remote location will make validation framework to pull dependencies expressed using relative `$ref` URIs from the remote hosts. In this example, `VpcId` property will be verified against the schema for `AWS::EC2::VPC.Name` hosted at `https://schema.cloudformation.us-east-1.amazonaws.com/aws-ec2-vpc.json`  
+Setting the $id property to a remote location will make validation framework to pull dependencies expressed using relative `$ref` URIs from the remote hosts. In this example, `VpcId` property will be verified against the schema for `AWS::EC2::VPC.Name` hosted at `https://schema.cloudformation.us-east-1.amazonaws.com/aws-ec2-vpc.json`
 
 ```
 {

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -212,9 +212,9 @@
     "type": "object",
     "patternProperties": {
         "^\\$id$": {
-            "$ref" : "https://json-schema.org/draft-07/schema#/properties/$id"
+            "$ref": "https://json-schema.org/draft-07/schema#/properties/$id"
         }
-    },   
+    },
     "properties": {
         "$schema": {
             "$ref": "https://json-schema.org/draft-07/schema#/properties/$schema"

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -210,6 +210,11 @@
         }
     },
     "type": "object",
+    "patternProperties": {
+        "^\\$id$": {
+            "$ref" : "https://json-schema.org/draft-07/schema#/properties/$id"
+        }
+    },   
     "properties": {
         "$schema": {
             "$ref": "https://json-schema.org/draft-07/schema#/properties/$schema"

--- a/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
@@ -331,6 +331,14 @@ public class ValidatorTest {
         validator.validateResourceDefinition(definition);
     }
 
+    @Test
+    public void validateDefinition_validRelativeRef_shouldNotThrow() {
+        final JSONObject definition = new JSONObject(new JSONTokener(this.getClass()
+            .getResourceAsStream("/valid-with-relative-ref.json")));
+
+        validator.validateResourceDefinition(definition);
+    }
+
     @ParameterizedTest
     @ValueSource(strings = { "ftp://example.com", "http://example.com", "git://example.com", "https://", })
     public void validateDefinition_nonMatchingDocumentationUrl_shouldThrow(final String documentationUrl) {
@@ -391,4 +399,13 @@ public class ValidatorTest {
 
         validator.validateResourceDefinition(definition);
     }
+
+    @Test
+    public void validateDefinition_idKeyword_shouldBeAllowed() {
+        final JSONObject definition = baseSchema().put("$id",
+            "https://schema.cloudformation.us-east-1.amazonaws.com/aws-ec2-instance.json#");
+
+        validator.validateResourceDefinition(definition);
+    }
+
 }

--- a/src/test/resources/valid-with-relative-ref.json
+++ b/src/test/resources/valid-with-relative-ref.json
@@ -1,0 +1,12 @@
+{
+  "$id": "https://schema.cloudformation.us-east-1.amazonaws.com/valid-with-relative-ref.json#",
+  "typeName": "AWS::Test::WithExternalRefs",
+  "description": "A test schema for unit tests.",
+  "properties": {
+    "StringProperty": {
+      "$ref": "aws-ecs-taskdefinition.json#/properties/blah"
+    }
+  },
+  "additionalProperties": false,
+  "primaryIdentifier" : ["/properties/StringProperty"]
+}

--- a/src/test/resources/valid-with-relative-ref.json
+++ b/src/test/resources/valid-with-relative-ref.json
@@ -1,12 +1,14 @@
 {
-  "$id": "https://schema.cloudformation.us-east-1.amazonaws.com/valid-with-relative-ref.json#",
-  "typeName": "AWS::Test::WithExternalRefs",
-  "description": "A test schema for unit tests.",
-  "properties": {
-    "StringProperty": {
-      "$ref": "aws-ecs-taskdefinition.json#/properties/blah"
-    }
-  },
-  "additionalProperties": false,
-  "primaryIdentifier" : ["/properties/StringProperty"]
+    "$id": "https://schema.cloudformation.us-east-1.amazonaws.com/valid-with-relative-ref.json#",
+    "typeName": "AWS::Test::WithExternalRefs",
+    "description": "A test schema for unit tests.",
+    "properties": {
+        "StringProperty": {
+            "$ref": "aws-ecs-taskdefinition.json#/properties/blah"
+        }
+    },
+    "additionalProperties": false,
+    "primaryIdentifier": [
+        "/properties/StringProperty"
+    ]
 }


### PR DESCRIPTION
*Issue #, if available:*

This change allows to use $id keyword in resource schema, which is necessary to support relative refs to other schemas, which in turn is needed for schema regionalization.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
