### PR TITLE
add custom stabilization timeout in handlers schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For each handler, you should define a list of API `permissions` required to perf
 
 ### timeoutInMinutes
 
-For each handler, you may define a `timeoutInMinutes` property, which defines the *maximum* timeout of the operation.  This timeout is used by the invoker of the handler (such as CloudFormation) to stop listening and cancel the operation.  Note that the handler may of course decide to timeout and return a failure prior to this max timeout period.
+For create, update, and delete handlers, you may define a `timeoutInMinutes` property, which defines the *maximum* timeout of the operation.  This timeout is used by the invoker of the handler (such as CloudFormation) to stop listening and cancel the operation.  Note that the handler may of course decide to timeout and return a failure prior to this max timeout period.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For each handler, you should define a list of API `permissions` required to perf
 
 ### timeoutInMinutes
 
-For create, update, and delete handlers, you may define a `timeoutInMinutes` property, which defines the *maximum* timeout of the operation.  This timeout is used by the invoker of the handler (such as CloudFormation) to stop listening and cancel the operation.  Note that the handler may of course decide to timeout and return a failure prior to this max timeout period.
+For each handler, you may define a `timeoutInMinutes` property, which defines the *maximum* timeout of the operation.  This timeout is used by the invoker of the handler (such as CloudFormation) to stop listening and cancel the operation.  Note that the handler may of course decide to timeout and return a failure prior to this max timeout period.  Currently, this value is only used for `Create`, `Update`, and `Delete` handlers, while `Read` and `List` handlers are expected to return synchronously within 30 seconds.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ We have taken an opinion on certain aspects of the core JSON Schema and introduc
 ### New Schema-Level Properties
 
 #### insertionOrder
+
 Array types can define a boolean `insertionOrder`, which specifies whether the order in which elements are specified should be honored when processing a diff between two sets of properties.  If `insertionOrder` is true, then a change in order of the elements will constitute a diff.  The default for `insertionOrder` is true.
 
 Together with the `uniqueItems` property (which is native to JSON Schema), complex array types can be defined, as in the following table:
@@ -138,6 +139,18 @@ Together with the `uniqueItems` property (which is native to JSON Schema), compl
 * **`additionalProperties`** use of `additionalProperties` is not valid for a resource property. Use `patternProperties` instead to define the shape and allowed values of extraneous keys.
 * **`properties` and `patternProperties`** it is not valid to use both properties and patternProperties together in the same shape, as a shape should not contain both defined and undefined values. In order to implement this, the set of undefined values should itself be a subshape.
 * **`items` and `additionalItems`** the `items` in an array may only have one schema and may not use a list of schemas, as an ordered tuple of different objects is confusing for both developers and customers. This should be expressed as key:value object pairs. Similarly, `additionalItems` is not allowed.
+
+## handlers
+
+The `handlers` section of the schema allows you to specify which CRUDL operations (create, read, update, delete, list) are available for your resource, as well as some additional metadata about each handler.
+
+### permissions
+
+For each handler, you should define a list of API `permissions` required to perform the operation.  Currently, this is used to generate IAM policy templates and is assumed to be AWS API permissions, but you may list 3rd party APIs here as well.
+
+### timeoutInMinutes
+
+For each handler, you may define a `timeoutInMinutes` property, which defines the *maximum* timeout of the operation.  This timeout is used by the invoker of the handler (such as CloudFormation) to stop listening and cancel the operation.  Note that the handler may of course decide to timeout and return a failure prior to this max timeout period.
 
 ## License
 

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -10,7 +10,7 @@
             "maxLength": 4096
         },
         "cudHandlerDefinition": {
-            "description": "Defines any execution operations which can be performed on this resource provider",
+            "description": "Defines create, update, and delete operations which can be performed on this resource provider",
             "type": "object",
             "properties": {
                 "permissions": {
@@ -30,7 +30,7 @@
             ]
         },
         "rlHandlerDefinition": {
-            "description": "Defines any execution operations which can be performed on this resource provider",
+            "description": "Defines read and list operations which can be performed on this resource provider",
             "type": "object",
             "properties": {
                 "permissions": {

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -19,6 +19,13 @@
                         "type": "string"
                     },
                     "additionalItems": false
+                },
+                "timeoutInMinutes": {
+                    "description": "Defines the timeout for the entire operation to be interpreted by the invoker of the handler.  The default is 120 (2 hours).",
+                    "type": "integer",
+                    "minimum": 2,
+                    "maximum": 4320,
+                    "default": 120
                 }
             },
             "additionalProperties": false,

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -9,22 +9,18 @@
             "pattern": "^https://[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z])(:[0-9]*)*([?/#].*)?$",
             "maxLength": 4096
         },
-        "handlerDefinition": {
+        "cudHandlerDefinition": {
             "description": "Defines any execution operations which can be performed on this resource provider",
             "type": "object",
             "properties": {
                 "permissions": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "additionalItems": false
+                    "$ref": "#/definitions/permissionsDefinition"
                 },
                 "timeoutInMinutes": {
                     "description": "Defines the timeout for the entire operation to be interpreted by the invoker of the handler.  The default is 120 (2 hours).",
                     "type": "integer",
                     "minimum": 2,
-                    "maximum": 4320,
+                    "maximum": 720,
                     "default": 120
                 }
             },
@@ -32,6 +28,26 @@
             "required": [
                 "permissions"
             ]
+        },
+        "rlHandlerDefinition": {
+            "description": "Defines any execution operations which can be performed on this resource provider",
+            "type": "object",
+            "properties": {
+                "permissions": {
+                    "$ref": "#/definitions/permissionsDefinition"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "permissions"
+            ]
+        },
+        "permissionsDefinition": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "additionalItems": false
         },
         "jsonPointerArray": {
             "type": "array",
@@ -289,19 +305,19 @@
             "type": "object",
             "properties": {
                 "create": {
-                    "$ref": "#/definitions/handlerDefinition"
+                    "$ref": "#/definitions/cudHandlerDefinition"
                 },
                 "read": {
-                    "$ref": "#/definitions/handlerDefinition"
+                    "$ref": "#/definitions/rlHandlerDefinition"
                 },
                 "update": {
-                    "$ref": "#/definitions/handlerDefinition"
+                    "$ref": "#/definitions/cudHandlerDefinition"
                 },
                 "delete": {
-                    "$ref": "#/definitions/handlerDefinition"
+                    "$ref": "#/definitions/cudHandlerDefinition"
                 },
                 "list": {
-                    "$ref": "#/definitions/handlerDefinition"
+                    "$ref": "#/definitions/rlHandlerDefinition"
                 }
             },
             "additionalProperties": false

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -9,12 +9,16 @@
             "pattern": "^https://[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z])(:[0-9]*)*([?/#].*)?$",
             "maxLength": 4096
         },
-        "cudHandlerDefinition": {
-            "description": "Defines create, update, and delete operations which can be performed on this resource provider",
+        "handlerDefinition": {
+            "description": "Defines any execution operations which can be performed on this resource provider",
             "type": "object",
             "properties": {
                 "permissions": {
-                    "$ref": "#/definitions/permissionsDefinition"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "additionalItems": false
                 },
                 "timeoutInMinutes": {
                     "description": "Defines the timeout for the entire operation to be interpreted by the invoker of the handler.  The default is 120 (2 hours).",
@@ -28,26 +32,6 @@
             "required": [
                 "permissions"
             ]
-        },
-        "rlHandlerDefinition": {
-            "description": "Defines read and list operations which can be performed on this resource provider",
-            "type": "object",
-            "properties": {
-                "permissions": {
-                    "$ref": "#/definitions/permissionsDefinition"
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "permissions"
-            ]
-        },
-        "permissionsDefinition": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "additionalItems": false
         },
         "jsonPointerArray": {
             "type": "array",
@@ -305,19 +289,19 @@
             "type": "object",
             "properties": {
                 "create": {
-                    "$ref": "#/definitions/cudHandlerDefinition"
+                    "$ref": "#/definitions/handlerDefinition"
                 },
                 "read": {
-                    "$ref": "#/definitions/rlHandlerDefinition"
+                    "$ref": "#/definitions/handlerDefinition"
                 },
                 "update": {
-                    "$ref": "#/definitions/cudHandlerDefinition"
+                    "$ref": "#/definitions/handlerDefinition"
                 },
                 "delete": {
-                    "$ref": "#/definitions/cudHandlerDefinition"
+                    "$ref": "#/definitions/handlerDefinition"
                 },
                 "list": {
-                    "$ref": "#/definitions/rlHandlerDefinition"
+                    "$ref": "#/definitions/handlerDefinition"
                 }
             },
             "additionalProperties": false

--- a/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
@@ -336,8 +336,7 @@ public class ValidatorTest {
         final String keyword = timeout == 1 ? "minimum" : "maximum";
 
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
-            .withNoCause().withMessage(
-                String.format("#/handlers/create/timeoutInMinutes: failed validation constraint for keyword [%s]", keyword));
+            .withNoCause().withMessageContaining("#/handlers/create/timeoutInMinutes").withMessageContaining(keyword);
     }
 
     @ParameterizedTest
@@ -374,8 +373,8 @@ public class ValidatorTest {
         handlerDefinition.put("timeoutInMinutes", 30);
 
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
-            .withNoCause()
-            .withMessage(String.format("#/handlers/%s: extraneous key [timeoutInMinutes] is not permitted", handlerType));
+            .withNoCause().withMessageContaining(String.format("#/handlers/%s", handlerType))
+            .withMessageContaining("timeoutInMinutes");
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
@@ -323,6 +323,34 @@ public class ValidatorTest {
             .withNoCause().withMessage("#/handlers/read: required key [permissions] not found");
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 4321 })
+    public void validateDefinition_invalidTimeout_shouldThrow(final int timeout) {
+        // modifying the valid-with-handlers.json to add invalid timeout
+        final JSONObject definition = new JSONObject(new JSONTokener(this.getClass()
+                .getResourceAsStream("/valid-with-handlers.json")));
+
+        final JSONObject createDefinition = definition.getJSONObject("handlers").getJSONObject("create");
+        createDefinition.put("timeoutInMinutes", timeout);
+
+        final String keyword = timeout == 1 ? "minimum" : "maximum";
+
+        assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
+                .withNoCause().withMessage(String.format("#/handlers/create/timeoutInMinutes: failed validation constraint for keyword [%s]", keyword));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 2, 100, 4320 })
+    public void validateDefinition_withTimeout_shouldNotThrow(final int timeout) {
+        final JSONObject definition = new JSONObject(new JSONTokener(this.getClass()
+                .getResourceAsStream("/valid-with-handlers.json")));
+
+        final JSONObject createDefinition = definition.getJSONObject("handlers").getJSONObject("create");
+        createDefinition.put("timeoutInMinutes", timeout);
+
+        validator.validateResourceDefinition(definition);
+    }
+
     @Test
     public void validateDefinition_validHandlerSection_shouldNotThrow() {
         final JSONObject definition = new JSONObject(new JSONTokener(this.getClass()

--- a/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
@@ -352,7 +352,7 @@ public class ValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "create", "update", "delete" })
+    @ValueSource(strings = { "create", "update", "delete", "read", "list" })
     public void validateDefinition_timeoutAllowed_shouldNotThrow(final String handlerType) {
         final JSONObject definition = new JSONObject(new JSONTokener(this.getClass()
             .getResourceAsStream("/valid-with-handlers.json")));
@@ -361,20 +361,6 @@ public class ValidatorTest {
         handlerDefinition.put("timeoutInMinutes", 30);
 
         validator.validateResourceDefinition(definition);
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "read", "list" })
-    public void validateDefinition_noTimeoutAllowed_shouldThrow(final String handlerType) {
-        final JSONObject definition = new JSONObject(new JSONTokener(this.getClass()
-            .getResourceAsStream("/valid-with-handlers.json")));
-
-        final JSONObject handlerDefinition = definition.getJSONObject("handlers").getJSONObject(handlerType);
-        handlerDefinition.put("timeoutInMinutes", 30);
-
-        assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
-            .withNoCause().withMessageContaining(String.format("#/handlers/%s", handlerType))
-            .withMessageContaining("timeoutInMinutes");
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds a new parameter `timeoutInMinutes` to the `handlerDefinition`, in order for providers to specify a custom stabilization timeout, to be used by CloudFormation. This could be used by the handler itself at some point to stop doing work.

I used `timeoutInMinutes` since it is much simpler for handlers rather than specifying some ISO format, and I don't see any need to have any more granularity than that

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
