### PR TITLE
Adding methods to remove writeOnlyProperties from model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,6 @@
             <artifactId>org.everit.json.schema</artifactId>
             <version>1.11.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
         <dependency>
             <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>org.everit.json.schema</artifactId>
             <version>1.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.9</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
         <dependency>
             <groupId>org.assertj</groupId>

--- a/src/main/java/org/everit/json/schema/PublicJSONPointer.java
+++ b/src/main/java/org/everit/json/schema/PublicJSONPointer.java
@@ -1,0 +1,42 @@
+/*
+* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+package org.everit.json.schema;
+
+import java.util.List;
+
+import org.json.JSONObject;
+
+public class PublicJSONPointer extends JSONPointer {
+
+    public PublicJSONPointer(final List<String> refTokens) {
+        super(refTokens);
+    }
+
+    public PublicJSONPointer(final String pointer) {
+        super(pointer);
+    }
+
+    public List<String> getRefTokens() {
+        return super.getRefTokens();
+    }
+
+    public boolean isInObject(final JSONObject jsonObject) {
+        try {
+            return this.queryFrom(jsonObject) != null;
+        } catch (JSONPointerException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -149,9 +149,8 @@ public class ResourceTypeSchema extends ObjectSchema {
     }
 
     public void removeWriteOnlyProperties(final JSONObject resourceModel) {
-        this.getWriteOnlyPropertiesAsStrings().stream()
-            .forEach(writeOnlyProperty -> removeProperty(new PublicJSONPointer(writeOnlyProperty.replaceFirst("/properties", "")),
-                resourceModel));
+        this.getWriteOnlyPropertiesAsStrings().stream().forEach(writeOnlyProperty -> removeProperty(
+            new PublicJSONPointer(writeOnlyProperty.replaceFirst("^/properties", "")), resourceModel));
     }
 
     public static void removeProperty(final PublicJSONPointer property, final JSONObject resourceModel) {

--- a/src/test/java/org/everit/json/schema/PublicJSONPointerTest.java
+++ b/src/test/java/org/everit/json/schema/PublicJSONPointerTest.java
@@ -1,0 +1,50 @@
+/*
+* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+package org.everit.json.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+public class PublicJSONPointerTest {
+    @Test
+    public void isInObject_objectHasProperty_shouldReturnTrue() {
+        final JSONObject jsonObject = new JSONObject().put("propertyThatExists", "value");
+        assertThat(new PublicJSONPointer("/propertyThatExists").isInObject(jsonObject)).isTrue();
+    }
+
+    @Test
+    public void isInObject_nestedObjectHasProperty_shouldReturnTrue() {
+        final JSONObject jsonObject = new JSONObject().put("propertyThatExists", new JSONObject().put("nested", "value"));
+        assertThat(new PublicJSONPointer(Arrays.asList("propertyThatExists", "nested")).isInObject(jsonObject)).isTrue();
+    }
+
+    @Test
+    public void isInObject_nestedObjectDoesNotHaveProperty_shouldReturnFalse() {
+        final JSONObject jsonObject = new JSONObject();
+        assertThat(new PublicJSONPointer(Arrays.asList("propertyThatExists", "nested")).isInObject(jsonObject)).isFalse();
+    }
+
+    @Test
+    public void isInObject_objectDoesNotHaveProperty_shouldReturnFalse() {
+        final JSONObject jsonObject = new JSONObject();
+        assertThat(new PublicJSONPointer("/propertyThatDoesNotExist").isInObject(jsonObject)).isFalse();
+
+    }
+
+}

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -30,6 +30,7 @@ public class ResourceTypeSchemaTest {
     private static final String EMPTY_SCHEMA_PATH = "/empty-schema.json";
     private static final String MINIMAL_SCHEMA_PATH = "/minimal-schema.json";
     private static final String NO_ADDITIONAL_PROPERTIES_SCHEMA_PATH = "/no-additional-properties-schema.json";
+    private static final String WRITEONLY_MODEL_PATH = "/write-only-model.json";
 
     @Test
     public void getProperties() {
@@ -95,7 +96,7 @@ public class ResourceTypeSchemaTest {
         final ResourceTypeSchema schema = ResourceTypeSchema.load(o);
 
         List<String> result = schema.getWriteOnlyPropertiesAsStrings();
-        assertThat(result).containsExactly("/properties/propertyC");
+        assertThat(result).containsExactly("/properties/propertyC", "/properties/propertyE/nestedProperty");
     }
 
     @Test
@@ -130,5 +131,36 @@ public class ResourceTypeSchemaTest {
         assertThat(schema.getAdditionalIdentifiersAsStrings()).isEmpty();
         assertThat(schema.getReadOnlyPropertiesAsStrings()).isEmpty();
         assertThat(schema.getWriteOnlyPropertiesAsStrings()).isEmpty();
+    }
+
+    @Test
+    public void removeWriteOnlyProperties_hasWriteOnlyProperties_shouldRemove() {
+        JSONObject o = new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)));
+        ResourceTypeSchema schema = ResourceTypeSchema.load(o);
+        JSONObject resourceModel = new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(WRITEONLY_MODEL_PATH)));
+
+        schema.removeWriteOnlyProperties(resourceModel);
+
+        // check that model doesn't contain the writeOnly properties
+        assertThat(schema.hasWriteOnlyProperties(resourceModel)).isFalse();
+        // ensure that other non writeOnlyProperty is not removed
+        assertThat(resourceModel.has("propertyB")).isTrue();
+    }
+
+    @Test
+    public void hasWriteOnlyProperties_noWriteOnlyProperties_shouldReturnFalse() {
+        JSONObject o = new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)));
+        ResourceTypeSchema schema = ResourceTypeSchema.load(o);
+
+        assertThat(schema.hasWriteOnlyProperties(new JSONObject())).isFalse();
+    }
+
+    @Test
+    void hasWriteOnlyProperties_writeOnlyProperties_shouldReturnTrue() {
+        JSONObject o = new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)));
+        ResourceTypeSchema schema = ResourceTypeSchema.load(o);
+        JSONObject resourceModel = new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(WRITEONLY_MODEL_PATH)));
+
+        assertThat(schema.hasWriteOnlyProperties(resourceModel)).isTrue();
     }
 }

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.List;
 
+import org.everit.json.schema.PublicJSONPointer;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.jupiter.api.Test;
@@ -142,25 +143,12 @@ public class ResourceTypeSchemaTest {
         schema.removeWriteOnlyProperties(resourceModel);
 
         // check that model doesn't contain the writeOnly properties
-        assertThat(schema.hasWriteOnlyProperties(resourceModel)).isFalse();
+
+        assertThat(schema.getWriteOnlyPropertiesAsStrings().stream()
+            .anyMatch(writeOnlyProperty -> new PublicJSONPointer(writeOnlyProperty.replaceFirst("/properties", ""))
+                .isInObject(resourceModel))).isFalse();
+
         // ensure that other non writeOnlyProperty is not removed
         assertThat(resourceModel.has("propertyB")).isTrue();
-    }
-
-    @Test
-    public void hasWriteOnlyProperties_noWriteOnlyProperties_shouldReturnFalse() {
-        JSONObject o = new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)));
-        ResourceTypeSchema schema = ResourceTypeSchema.load(o);
-
-        assertThat(schema.hasWriteOnlyProperties(new JSONObject())).isFalse();
-    }
-
-    @Test
-    void hasWriteOnlyProperties_writeOnlyProperties_shouldReturnTrue() {
-        JSONObject o = new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(TEST_SCHEMA_PATH)));
-        ResourceTypeSchema schema = ResourceTypeSchema.load(o);
-        JSONObject resourceModel = new JSONObject(new JSONTokener(this.getClass().getResourceAsStream(WRITEONLY_MODEL_PATH)));
-
-        assertThat(schema.hasWriteOnlyProperties(resourceModel)).isTrue();
     }
 }

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -145,7 +145,7 @@ public class ResourceTypeSchemaTest {
         // check that model doesn't contain the writeOnly properties
 
         assertThat(schema.getWriteOnlyPropertiesAsStrings().stream()
-            .anyMatch(writeOnlyProperty -> new PublicJSONPointer(writeOnlyProperty.replaceFirst("/properties", ""))
+            .anyMatch(writeOnlyProperty -> new PublicJSONPointer(writeOnlyProperty.replaceFirst("^/properties", ""))
                 .isInObject(resourceModel))).isFalse();
 
         // ensure that other non writeOnlyProperty is not removed

--- a/src/test/resources/test-schema.json
+++ b/src/test/resources/test-schema.json
@@ -17,6 +17,17 @@
         },
         "propertyD": {
             "type": "boolean"
+        },
+        "propertyE": {
+            "type": "object",
+            "properties": {
+                "nestedProperty": {
+                    "type": "string"
+                },
+                "writeOnlyArray": {
+                    "type": "string"
+                }
+            }
         }
     },
     "required": [
@@ -33,7 +44,8 @@
         "/properties/propertyB"
     ],
     "writeOnlyProperties": [
-        "/properties/propertyC"
+        "/properties/propertyC",
+        "/properties/propertyE/nestedProperty"
     ],
     "primaryIdentifier": [
         "/properties/propertyA"

--- a/src/test/resources/write-only-model.json
+++ b/src/test/resources/write-only-model.json
@@ -1,12 +1,15 @@
 {
-  "propertyB": [
-    1,
-    22,
-    3
-  ],
-  "propertyC": "writeOnly",
-  "propertyE": {
-    "nestedProperty": "something write only",
-    "writeOnlyArray": ["writeOnly", "notWriteOnly"]
-  }
+    "propertyB": [
+        1,
+        22,
+        3
+    ],
+    "propertyC": "writeOnly",
+    "propertyE": {
+        "nestedProperty": "something write only",
+        "writeOnlyArray": [
+            "writeOnly",
+            "notWriteOnly"
+        ]
+    }
 }

--- a/src/test/resources/write-only-model.json
+++ b/src/test/resources/write-only-model.json
@@ -1,0 +1,12 @@
+{
+  "propertyB": [
+    1,
+    22,
+    3
+  ],
+  "propertyC": "writeOnly",
+  "propertyE": {
+    "nestedProperty": "something write only",
+    "writeOnlyArray": ["writeOnly", "notWriteOnly"]
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adding some methods to the ResourceSchema class to determine if a given model has writeOnlyProperties and also a method to remove the properties. Tried to make it extensible so that the same thing could be applied to other groups of properties.

I did not handle cases for writeOnlyProperties that were items in arrays, as I was unsure on if this was allowed or what the behavior should be. Say, if "/properties/arrayProperty/0" is writeOnly, and the array has two items, if we remove one, then the object still appears to have a writeOnlyProperty after removal:
```
{
   "arrayProperty": [0, 1]
}
```
After:
```
{
   "arrayProperty": [1] //still has item at "/properties/arrayProperty/0"
}
```
Input on this would be great.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
