### PR TITLE
Service Link

### DIFF
--- a/src/main/resources/examples/resource/initech.tps.report.v1.json
+++ b/src/main/resources/examples/resource/initech.tps.report.v1.json
@@ -100,7 +100,7 @@
             ]
         }
     },
-    "serviceLink": {
+    "resourceLink": {
         "$comment": "This is an example of a relative, AWS-internal service link. For external links, use an absolute URI.",
         "templateUri": "/tps/v2/home?region=${awsRegion}#Report:tpsCode=${TPSCode}",
         "mappings": {

--- a/src/main/resources/examples/resource/initech.tps.report.v1.json
+++ b/src/main/resources/examples/resource/initech.tps.report.v1.json
@@ -100,5 +100,12 @@
             ]
         }
     },
+    "serviceLink": {
+        "$comment": "This is an example of a relative, AWS-internal service link. For external links, use an absolute URI.",
+        "templateUri": "/tps/v2/home?region=${awsRegion}#Report:tpsCode=${TPSCode}",
+        "mappings": {
+            "TPSCode": "/TPSCode"
+        }
+    },
     "additionalProperties": false
 }

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -207,6 +207,33 @@
                     "additionalProperties": false
                 }
             ]
+        },
+        "serviceLink": {
+            "type": "object",
+            "properties": {
+                "$comment": {
+                    "$ref": "https://json-schema.org/draft-07/schema#/properties/$comment"
+                },
+                "templateUri": {
+                    "type": "string",
+                    "pattern": "^(/|https:)"
+                },
+                "mappings": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[A-Za-z0-9]{1,64}$": {
+                            "type": "string",
+                            "format": "json-pointer"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "templateUri",
+                "mappings"
+            ],
+            "additionalProperties": false
         }
     },
     "type": "object",
@@ -366,6 +393,10 @@
         },
         "oneOf": {
             "$ref": "#/definitions/schemaArray"
+        },
+        "serviceLink": {
+            "description": "A template-able link to a resource instance. AWS-internal service links must be relative to the AWS console domain. External service links must be absolute, HTTPS URIs.",
+            "$ref": "#/definitions/serviceLink"
         }
     },
     "required": [

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -208,7 +208,7 @@
                 }
             ]
         },
-        "serviceLink": {
+        "resourceLink": {
             "type": "object",
             "properties": {
                 "$comment": {
@@ -394,9 +394,9 @@
         "oneOf": {
             "$ref": "#/definitions/schemaArray"
         },
-        "serviceLink": {
+        "resourceLink": {
             "description": "A template-able link to a resource instance. AWS-internal service links must be relative to the AWS console domain. External service links must be absolute, HTTPS URIs.",
-            "$ref": "#/definitions/serviceLink"
+            "$ref": "#/definitions/resourceLink"
         }
     },
     "required": [

--- a/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
@@ -404,32 +404,32 @@ public class ValidatorTest {
 
     @Test
     public void validateDefinition_relativeTemplateUri_shouldBeAllowed() {
-        final JSONObject serviceLink = new JSONObject().put("templateUri", "/cloudformation/home").put("mappings",
+        final JSONObject resourceLink = new JSONObject().put("templateUri", "/cloudformation/home").put("mappings",
             new JSONObject());
-        final JSONObject definition = baseSchema().put("serviceLink", serviceLink);
+        final JSONObject definition = baseSchema().put("resourceLink", resourceLink);
 
         validator.validateResourceDefinition(definition);
     }
 
     @Test
     public void validateDefinition_httpsTemplateUri_shouldBeAllowed() {
-        final JSONObject serviceLink = new JSONObject()
+        final JSONObject resourceLink = new JSONObject()
             .put("templateUri", "https://eu-central-1.console.aws.amazon.com/cloudformation/home")
             .put("mappings", new JSONObject());
-        final JSONObject definition = baseSchema().put("serviceLink", serviceLink);
+        final JSONObject definition = baseSchema().put("resourceLink", resourceLink);
 
         validator.validateResourceDefinition(definition);
     }
 
     @Test
     public void validateDefinition_httpTemplateUri_shouldThrow() {
-        final JSONObject serviceLink = new JSONObject()
+        final JSONObject resourceLink = new JSONObject()
             .put("templateUri", "http://eu-central-1.console.aws.amazon.com/cloudformation/home")
             .put("mappings", new JSONObject());
-        final JSONObject definition = baseSchema().put("serviceLink", serviceLink);
+        final JSONObject definition = baseSchema().put("resourceLink", resourceLink);
 
         assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
-            .withMessageContaining("#/serviceLink/templateUri");
+            .withMessageContaining("#/resourceLink/templateUri");
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
@@ -403,6 +403,36 @@ public class ValidatorTest {
     }
 
     @Test
+    public void validateDefinition_relativeTemplateUri_shouldBeAllowed() {
+        final JSONObject serviceLink = new JSONObject().put("templateUri", "/cloudformation/home").put("mappings",
+            new JSONObject());
+        final JSONObject definition = baseSchema().put("serviceLink", serviceLink);
+
+        validator.validateResourceDefinition(definition);
+    }
+
+    @Test
+    public void validateDefinition_httpsTemplateUri_shouldBeAllowed() {
+        final JSONObject serviceLink = new JSONObject()
+            .put("templateUri", "https://eu-central-1.console.aws.amazon.com/cloudformation/home")
+            .put("mappings", new JSONObject());
+        final JSONObject definition = baseSchema().put("serviceLink", serviceLink);
+
+        validator.validateResourceDefinition(definition);
+    }
+
+    @Test
+    public void validateDefinition_httpTemplateUri_shouldThrow() {
+        final JSONObject serviceLink = new JSONObject()
+            .put("templateUri", "http://eu-central-1.console.aws.amazon.com/cloudformation/home")
+            .put("mappings", new JSONObject());
+        final JSONObject definition = baseSchema().put("serviceLink", serviceLink);
+
+        assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> validator.validateResourceDefinition(definition))
+            .withMessageContaining("#/serviceLink/templateUri");
+    }
+
+    @Test
     public void validateDefinition_idKeyword_shouldBeAllowed() {
         final JSONObject definition = baseSchema().put("$id",
             "https://schema.cloudformation.us-east-1.amazonaws.com/aws-ec2-instance.json#");


### PR DESCRIPTION
*Issue #, if available:* #62 

*Description of changes:* Allow resource authors to attach template links to the schema that consumers of the schema/resources can use to generate links directly to the resource. An example might be EC2. The console link is:

```
https://eu-central-1.console.aws.amazon.com/ec2/home?region=eu-central-1#Instances:instanceId=i-xxxxxx
```

In this case, the service link might look like this:

```
"serviceLink": {
    "templateUri": "/ec2/home?region=${awsRegion}#Instances:instanceId=${instanceId}",
    "mappings": {
        "instanceId": "/InstanceId"
    }
},
```

Where `awsRegion` is a "global" variable (so far, the only one), and `instanceId` is a variable defined via a JSON pointer to a property *in a resource blob* (returned by e.g. READ) and not in the schema. The relative URI is debatable, but works well for the console currently. Other users outside of the console would have to maintain a mapping of console endpoints by region. The other benefit is that it lets us clearly figure out which links are AWS-internal.

For non-AWS services, an absolute, HTTPS URI can be used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
