### PR TITLE
Bumping version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <description>This library contains the metaschema for CloudFormation resource types and validation tools.</description>
     <url>ttps://github.com/aws-cloudformation/aws-cloudformation-resource-schema</url>
 
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -40,7 +40,6 @@
         <connection>scm:git:https://github.com/aws-cloudformation/aws-cloudformation-resource-schema.git</connection>
         <developerConnection>scm:git:git@github.com:aws-cloudformation/aws-cloudformation-resource-schema.git</developerConnection>
         <url>https://github.com/aws-cloudformation/aws-cloudformation-resource-schema</url>
-        <tag>aws-cloudformation-resource-schema-2.0.1</tag>
     </scm>
     <dependencies>
         <!-- https://mvnrepository.com/artifact/com.github.everit-org.json-schema/org.everit.json.schema -->


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Bumping version so I can have an updated dependency to make changes in the java plugin related to #64. I removed the scm tag as we don't need the tag [(rpdk java library does not have it)](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/pom.xml#L34). Becomes one less thing to worry about updating.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
