### PR TITLE
Set new pyenv version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 jdk: openjdk11
 env:
   global:
-    - PYENV_VERSION=3.7.1
+    - PYENV_VERSION=3.7
 install:
   - pip3 install --user pre-commit
 script:


### PR DESCRIPTION
*Issue #, if available:* #69 

*Description of changes:* Travis have recently updated their base image of bionic (Tue Dec 17 14:57:15 UTC 2019). Unfortunately, this has also changed the pre-baked Python versions from:

```bash
$ pyenv versions
* system (set by /opt/pyenv/version)
  2.7.15
  3.6.7
  3.7.1
```

to:

```bash
$ pyenv versions
* system (set by /opt/pyenv/version)
  2.7
  2.7.17
  3.6
  3.6.9
  3.7
  3.7.5
  3.8
  3.8.0
```

I think this is still an easy solution, the alternative was something like:

```bash
$ pyenv versions | grep '3.8' | sort -nr | head -n1 | xargs pyenv local
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
