### PR TITLE
Make ctor Validator(SchemaClient downloader) public

### DIFF
--- a/src/main/java/software/amazon/cloudformation/resource/Validator.java
+++ b/src/main/java/software/amazon/cloudformation/resource/Validator.java
@@ -58,7 +58,7 @@ public class Validator implements SchemaValidator {
      */
     private final SchemaClient downloader;
 
-    Validator(SchemaClient downloader) {
+    public Validator(SchemaClient downloader) {
         this(loadResourceAsJSON(JSON_SCHEMA_PATH), loadResourceAsJSON(RESOURCE_DEFINITION_SCHEMA_PATH), downloader);
     }
 


### PR DESCRIPTION
*Description of changes:*

I have a use case where a consumer of this package would like to run schema validation tests without opening an internet connection. Making Validator(SchemaClient downloader) public enables this use case - I can inject a mock SchemaClient and avoid mocking an entire HTTP server



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
