### PR TITLE
Readme: Fix example about references

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Relationships between resources can be expressed through the use of the `$ref` k
 
 #### Example
 
-The following example shows a property relationship between an `AWS::EC2::Subnet.VpcId` and an `AWS::EC2::VPC.Name`. The schema for the 'remote' type (`AWS::EC2::VPC`) is used to validate the content of the 'local' type (`AWS::EC2::Subnet`) and can be inferred as a dependency from the local to the remote type.
+The following example shows a property relationship between an `AWS::EC2::Subnet.VpcId` and an `AWS::EC2::VPC.Id`. The schema for the 'remote' type (`AWS::EC2::VPC`) is used to validate the content of the 'local' type (`AWS::EC2::Subnet`) and can be inferred as a dependency from the local to the remote type.
 
 Setting the $id property to a remote location will make validation framework to pull dependencies expressed using relative `$ref` URIs from the remote hosts. In this example, `VpcId` property will be verified against the schema for `AWS::EC2::VPC.Name` hosted at `https://schema.cloudformation.us-east-1.amazonaws.com/aws-ec2-vpc.json`
 
@@ -95,7 +95,7 @@ Setting the $id property to a remote location will make validation framework to 
     "properties": {
         { ... }
         "VpcId": {
-            "$ref": "aws-ec2-vpc.json#/properties/Name"
+            "$ref": "aws-ec2-vpc.json#/properties/Id"
         }
     }
 }
@@ -107,7 +107,7 @@ Setting the $id property to a remote location will make validation framework to 
     "typeName": "AWS::EC2::VPC",
     "definitions": { ... },
     "properties": {
-        "Name": {
+        "Id": {
             "type": "string",
             "pattern": "$vpc-[0-9]{8,10}^"
         }

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Relationships between resources can be expressed through the use of the `$ref` k
 
 The following example shows a property relationship between an `AWS::EC2::Subnet.VpcId` and an `AWS::EC2::VPC.Id`. The schema for the 'remote' type (`AWS::EC2::VPC`) is used to validate the content of the 'local' type (`AWS::EC2::Subnet`) and can be inferred as a dependency from the local to the remote type.
 
-Setting the $id property to a remote location will make validation framework to pull dependencies expressed using relative `$ref` URIs from the remote hosts. In this example, `VpcId` property will be verified against the schema for `AWS::EC2::VPC.Name` hosted at `https://schema.cloudformation.us-east-1.amazonaws.com/aws-ec2-vpc.json`
+Setting the $id property to a remote location will make validation framework to pull dependencies expressed using relative `$ref` URIs from the remote hosts. In this example, `VpcId` property will be verified against the schema for `AWS::EC2::VPC.Id` hosted at `https://schema.cloudformation.us-east-1.amazonaws.com/aws-ec2-vpc.json`
 
 ```
 {


### PR DESCRIPTION
*Description of changes:*
The example about references in the readme mentions a property called `Name` in AWS::EC2::VPC which doesn't exist in that schema. That is a bit confusing, so I would like to change it to `Id`.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
