### PR TITLE
Increase timeoutInMinutes from 720 to 2160

### DIFF
--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -24,7 +24,7 @@
                     "description": "Defines the timeout for the entire operation to be interpreted by the invoker of the handler.  The default is 120 (2 hours).",
                     "type": "integer",
                     "minimum": 2,
-                    "maximum": 720,
+                    "maximum": 2160,
                     "default": 120
                 }
             },

--- a/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ValidatorTest.java
@@ -323,7 +323,7 @@ public class ValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 1, 721 })
+    @ValueSource(ints = { 1, 2161 })
     public void validateDefinition_invalidTimeout_shouldThrow(final int timeout) {
         // modifying the valid-with-handlers.json to add invalid timeout
         final JSONObject definition = loadJSON(SCHEMA_WITH_HANDLERS_PATH);
@@ -338,7 +338,7 @@ public class ValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 2, 120, 720 })
+    @ValueSource(ints = { 2, 120, 720, 1440, 2160 })
     public void validateDefinition_withTimeout_shouldNotThrow(final int timeout) {
         final JSONObject definition = loadJSON(SCHEMA_WITH_HANDLERS_PATH);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* As we launched resource registry platform v2, the timeout limit has increased from 12 hrs to 36 hrs. Hence, we also need to increase **timeoutInMinutes** from 720 to 2160 (36 x 60) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
