### PR TITLE
Fixed GetAtt when combining property is in schema

### DIFF
--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -23,8 +23,10 @@ import java.util.stream.Collectors;
 
 import lombok.Getter;
 
+import org.everit.json.schema.CombinedSchema;
 import org.everit.json.schema.JSONPointer;
 import org.everit.json.schema.JSONPointerException;
+import org.everit.json.schema.ObjectSchema;
 import org.everit.json.schema.PublicJSONPointer;
 import org.everit.json.schema.Schema;
 import org.json.JSONObject;
@@ -175,7 +177,14 @@ public class ResourceTypeSchema {
     }
 
     public boolean definesProperty(String field) {
-        return schema.definesProperty(field);
+        // when schema contains a combining property such as "oneOf",
+        // schema will be a CombinedSchema and only its ObjectSchema subschema should be checked
+        Schema schemaToCheck = schema instanceof CombinedSchema
+            ? ((CombinedSchema) schema).getSubschemas().stream()
+                .filter(subschema -> subschema instanceof ObjectSchema)
+                .findFirst().get()
+            : schema;
+        return schemaToCheck.definesProperty(field);
     }
 
     public void validate(JSONObject json) {

--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -177,8 +177,14 @@ public class ResourceTypeSchema {
     }
 
     public boolean definesProperty(String field) {
-        // when schema contains a combining property such as "oneOf",
-        // schema will be a CombinedSchema and only its ObjectSchema subschema should be checked
+        // when schema contains combining properties (options are "oneOf", "anyOf", and "allOf"),
+        // schema will be a CombinedSchema with
+        // - an allOf criterion
+        // - subschemas
+        // - an ObjectSchema that contains properties to be checked
+        // - other CombinedSchemas corresponding to the usages of combining properties.
+        // These CombinedSchemas should be ignored. Otherwise, JSON schema's definesProperty method
+        // will search for field as a property in the CombinedSchema, which is not desired.
         Schema schemaToCheck = schema instanceof CombinedSchema
             ? ((CombinedSchema) schema).getSubschemas().stream()
                 .filter(subschema -> subschema instanceof ObjectSchema)

--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -177,7 +177,8 @@ public class ResourceTypeSchema {
     }
 
     public boolean definesProperty(String field) {
-        // when schema contains combining properties (options are "oneOf", "anyOf", and "allOf"),
+        // when schema contains combining properties
+        // (keywords for combining schemas together, with options being "oneOf", "anyOf", and "allOf"),
         // schema will be a CombinedSchema with
         // - an allOf criterion
         // - subschemas

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -30,6 +30,8 @@ public class ResourceTypeSchemaTest {
     private static final String TEST_SCHEMA_PATH = "/test-schema.json";
     private static final String EMPTY_SCHEMA_PATH = "/empty-schema.json";
     private static final String SCHEMA_WITH_ONEOF = "/valid-with-oneof-schema.json";
+    private static final String SCHEMA_WITH_ANYOF = "/valid-with-anyof-schema.json";
+    private static final String SCHEMA_WITH_ALLOF = "/valid-with-allof-schema.json";
     private static final String MINIMAL_SCHEMA_PATH = "/minimal-schema.json";
     private static final String NO_ADDITIONAL_PROPERTIES_SCHEMA_PATH = "/no-additional-properties-schema.json";
     private static final String WRITEONLY_MODEL_PATH = "/write-only-model.json";
@@ -163,14 +165,40 @@ public class ResourceTypeSchemaTest {
     }
 
     /**
-     * test definesProperty for when schema contains a combining property
-     * (keywords for combining schemas together, with options being "oneOf", "anyOf", and "allOf")
+     * test definesProperty for when schema contains "oneOf"
      */
     @Test
-    public void schemaWithCombiningProperty_definesProperty() {
+    public void schemaWithOneOf_definesProperty() {
         JSONObject resourceDefinition = loadJSON(SCHEMA_WITH_ONEOF);
         ResourceTypeSchema schema = ResourceTypeSchema.load(resourceDefinition);
 
+        assertThat(schema.definesProperty("id")).isTrue();
+        assertThat(schema.definesProperty("propertyA")).isTrue();
+        assertThat(schema.definesProperty("propertyNonExistent")).isFalse();
+    }
+
+    /**
+     * test definesProperty for when schema contains "anyOf"
+     */
+    @Test
+    public void schemaWithAnyOf_definesProperty() {
+        JSONObject resourceDefinition = loadJSON(SCHEMA_WITH_ANYOF);
+        ResourceTypeSchema schema = ResourceTypeSchema.load(resourceDefinition);
+
+        assertThat(schema.definesProperty("id")).isTrue();
+        assertThat(schema.definesProperty("propertyA")).isTrue();
+        assertThat(schema.definesProperty("propertyNonExistent")).isFalse();
+    }
+
+    /**
+     * test definesProperty for when schema contains "allOf"
+     */
+    @Test
+    public void schemaWithAllOf_definesProperty() {
+        JSONObject resourceDefinition = loadJSON(SCHEMA_WITH_ALLOF);
+        ResourceTypeSchema schema = ResourceTypeSchema.load(resourceDefinition);
+
+        assertThat(schema.definesProperty("id")).isTrue();
         assertThat(schema.definesProperty("propertyA")).isTrue();
         assertThat(schema.definesProperty("propertyNonExistent")).isFalse();
     }

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -154,6 +154,28 @@ public class ResourceTypeSchemaTest {
     }
 
     @Test
+    public void minimalSchema_definesProperty() {
+        JSONObject resourceDefinition = loadJSON(MINIMAL_SCHEMA_PATH);
+        ResourceTypeSchema schema = ResourceTypeSchema.load(resourceDefinition);
+
+        assertThat(schema.definesProperty("propertyA")).isTrue();
+        assertThat(schema.definesProperty("propertyNonExistent")).isFalse();
+    }
+
+    /**
+     * test definesProperty for when schema contains a combining property
+     * (keywords for combining schemas together, with options being "oneOf", "anyOf", and "allOf")
+     */
+    @Test
+    public void schemaWithCombiningProperty_definesProperty() {
+        JSONObject resourceDefinition = loadJSON(SCHEMA_WITH_ONEOF);
+        ResourceTypeSchema schema = ResourceTypeSchema.load(resourceDefinition);
+
+        assertThat(schema.definesProperty("propertyA")).isTrue();
+        assertThat(schema.definesProperty("propertyNonExistent")).isFalse();
+    }
+
+    @Test
     public void validSchema_withOneOf_shouldSucceed() {
         JSONObject resource = loadJSON("/valid-with-oneof-schema.json");
         final ResourceTypeSchema schema = ResourceTypeSchema.load(resource);

--- a/src/test/resources/valid-with-allof-schema.json
+++ b/src/test/resources/valid-with-allof-schema.json
@@ -1,0 +1,32 @@
+{
+    "typeName": "AWS::Test::TestModel",
+    "description": "A test schema for unit tests.",
+    "sourceUrl": "https://mycorp.com/my-repo.git",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "propertyA": {
+            "type": "string"
+        },
+        "propertyB": {
+            "type": "string"
+        }
+    },
+    "allOf": [
+        {
+            "required": [
+                "propertyA"
+            ]
+        },
+        {
+            "required": [
+                "propertyB"
+            ]
+        }
+    ],
+    "primaryIdentifier": [
+        "/properties/id"
+    ],
+    "additionalProperties": false
+}

--- a/src/test/resources/valid-with-anyof-schema.json
+++ b/src/test/resources/valid-with-anyof-schema.json
@@ -1,0 +1,32 @@
+{
+    "typeName": "AWS::Test::TestModel",
+    "description": "A test schema for unit tests.",
+    "sourceUrl": "https://mycorp.com/my-repo.git",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "propertyA": {
+            "type": "string"
+        },
+        "propertyB": {
+            "type": "string"
+        }
+    },
+    "anyOf": [
+        {
+            "required": [
+                "propertyA"
+            ]
+        },
+        {
+            "required": [
+                "propertyB"
+            ]
+        }
+    ],
+    "primaryIdentifier": [
+        "/properties/id"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
When the schema contains a [combining property](https://json-schema.org/understanding-json-schema/reference/combining.html) such as "oneOf", GetAtt calls fail with the error message "Requested attribute **[attribute]** does not exist in schema for **[typeName]**".

This PR fixes the issue by changing ResourceTypeSchema's definesProperty method.

### Tests

- minimal schema, schema with oneOf, schema with anyOf, schema with allOf
- checks that definesProperty correctly returns true or false depending on the whether the property exists

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
