### PR TITLE
Fix default taggable to boolean instead of string

### DIFF
--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -304,7 +304,7 @@
         "taggable": {
             "$comment": "A boolean flag indicating whether this resource type supports updatable tagging.",
             "type": "boolean",
-            "default": "true"
+            "default": true
         },
         "replacementStrategy": {
             "$comment": "The order of replacement for an immutable resource update.",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Default set a string of a boolean for taggable


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
