### PR TITLE
Add release job to staging repo

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,27 @@
+# This workflow will put the project in our staging repo
+name: Releasing Project to maven
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Java & publishing credentials
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+        server-id: sonatype-nexus-staging # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: SONATYPE_USERNAME # env variable for username in deploy
+        server-password: SONATYPE_PASSWORD  # env variable for token in deploy
+        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+    - name: Deploy to sonatype staging repo
+      run: mvn deploy -Ppublishing
+      env:
+        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR automates releases to our maven staging repo. Similar to https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/339

This release workflow uses the official java github action to set up the necessary credentials, and the deploy stage executes the command.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
