### PR TITLE
Add compare method for create only properties

### DIFF
--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -37,6 +37,8 @@ public class ResourceTypeSchemaTest {
     private static final String MINIMAL_SCHEMA_PATH = "/minimal-schema.json";
     private static final String NO_ADDITIONAL_PROPERTIES_SCHEMA_PATH = "/no-additional-properties-schema.json";
     private static final String WRITEONLY_MODEL_PATH = "/write-only-model.json";
+    private static final String CREATEONLY_MODEL_PATH = "/create-only-model.json";
+    private static final String CREATEONLY_CURRENT_MODEL_PATH = "/create-only-current-model.json";
     private static final String HANDLERS_SCHEMA_PATH = "/valid-with-handlers-schema.json";
 
     @Test
@@ -58,7 +60,8 @@ public class ResourceTypeSchemaTest {
 
         List<String> result = schema.getCreateOnlyPropertiesAsStrings();
 
-        assertThat(result).containsExactly("/properties/propertyA", "/properties/propertyD");
+        assertThat(result).containsExactly("/properties/propertyA", "/properties/propertyD",
+            "/properties/propertyE/nestedCreateOnlyProperty");
     }
 
     @Test
@@ -195,6 +198,29 @@ public class ResourceTypeSchemaTest {
 
         // ensure that other non writeOnlyProperty is not removed
         assertThat(resourceModel.has("propertyB")).isTrue();
+    }
+
+    @Test
+    public void compareCreateOnlyProperties_hasEqualCreateOnlyProperties() {
+        JSONObject o = loadJSON(TEST_SCHEMA_PATH);
+        ResourceTypeSchema schema = ResourceTypeSchema.load(o);
+        JSONObject resourceModel = loadJSON(CREATEONLY_MODEL_PATH);
+
+        final boolean result = schema.compareCreateOnlyProperties(resourceModel, resourceModel);
+
+        assertThat(result).isEqualTo(true);
+    }
+
+    @Test
+    public void compareCreateOnlyProperties_hasNotEqualCreateOnlyProperties() {
+        JSONObject o = loadJSON(TEST_SCHEMA_PATH);
+        ResourceTypeSchema schema = ResourceTypeSchema.load(o);
+        JSONObject previousResourceModel = loadJSON(CREATEONLY_MODEL_PATH);
+        JSONObject currentResourceModel = loadJSON(CREATEONLY_CURRENT_MODEL_PATH);
+
+        final boolean result = schema.compareCreateOnlyProperties(previousResourceModel, currentResourceModel);
+
+        assertThat(result).isEqualTo(false);
     }
 
     @Test

--- a/src/test/resources/create-only-current-model.json
+++ b/src/test/resources/create-only-current-model.json
@@ -1,0 +1,7 @@
+{
+    "propertyA": "createOnlyNotEqual",
+    "propertyD": true,
+    "propertyE": {
+        "nestedCreateOnlyProperty": "something write only"
+    }
+}

--- a/src/test/resources/create-only-model.json
+++ b/src/test/resources/create-only-model.json
@@ -1,0 +1,7 @@
+{
+    "propertyA": "createOnly",
+    "propertyD": true,
+    "propertyE": {
+        "nestedCreateOnlyProperty": "something write only"
+    }
+}

--- a/src/test/resources/test-schema.json
+++ b/src/test/resources/test-schema.json
@@ -26,6 +26,9 @@
                 },
                 "writeOnlyArray": {
                     "type": "string"
+                },
+                "nestedCreateOnlyProperty": {
+                    "type": "string"
                 }
             }
         }
@@ -39,7 +42,8 @@
     ],
     "createOnlyProperties": [
         "/properties/propertyA",
-        "/properties/propertyD"
+        "/properties/propertyD",
+        "/properties/propertyE/nestedCreateOnlyProperty"
     ],
     "deprecatedProperties": [
         "/properties/propertyC"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Right now, if the create only property passed to the update handler is different from the created model it is the handler's responsibility to throw a not update-able exception. This works for now. But in my opinion we should have this check in the language plugins and support this functionality on the framework vs asking the handlers to throw the right error code. This CR is creating a method to compare the previous model's create only property with the updated model's create only properties and if they are different the appropriate exception is going to be thrown by the language plugins. (Validation in language plugins will be a separate CR)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
