### PR TITLE
Adding conditionallyCreateOnlyProperties to metaschema

### DIFF
--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -52,7 +52,7 @@ public class ResourceTypeSchema {
     private final String replacementStrategy;
     private final boolean taggable;
     private final List<JSONPointer> createOnlyProperties = new ArrayList<>();
-    private final List<JSONPointer> conditionallyCreateOnlyProperties = new ArrayList<>();
+    private final List<JSONPointer> conditionalCreateOnlyProperties = new ArrayList<>();
     private final List<JSONPointer> deprecatedProperties = new ArrayList<>();
     private final List<JSONPointer> primaryIdentifier = new ArrayList<>();
     private final List<List<JSONPointer>> additionalIdentifiers = new ArrayList<>();
@@ -97,8 +97,8 @@ public class ResourceTypeSchema {
             : true;
         this.unprocessedProperties.remove("taggable");
 
-        this.unprocessedProperties.computeIfPresent("conditionallyCreateOnlyProperties", (k, v) -> {
-            ((ArrayList<?>) v).forEach(p -> this.conditionallyCreateOnlyProperties.add(new JSONPointer(p.toString())));
+        this.unprocessedProperties.computeIfPresent("conditionalCreateOnlyProperties", (k, v) -> {
+            ((ArrayList<?>) v).forEach(p -> this.conditionalCreateOnlyProperties.add(new JSONPointer(p.toString())));
             return null;
         });
 
@@ -165,8 +165,8 @@ public class ResourceTypeSchema {
         return schema.getDescription();
     }
 
-    public List<String> getConditionallyCreateOnlyPropertiesAsStrings() throws ValidationException {
-        return this.conditionallyCreateOnlyProperties.stream().map(JSONPointer::toString).collect(Collectors.toList());
+    public List<String> getConditionalCreateOnlyPropertiesAsStrings() throws ValidationException {
+        return this.conditionalCreateOnlyProperties.stream().map(JSONPointer::toString).collect(Collectors.toList());
     }
 
     public List<String> getCreateOnlyPropertiesAsStrings() throws ValidationException {

--- a/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
+++ b/src/main/java/software/amazon/cloudformation/resource/ResourceTypeSchema.java
@@ -52,6 +52,7 @@ public class ResourceTypeSchema {
     private final String replacementStrategy;
     private final boolean taggable;
     private final List<JSONPointer> createOnlyProperties = new ArrayList<>();
+    private final List<JSONPointer> conditionallyCreateOnlyProperties = new ArrayList<>();
     private final List<JSONPointer> deprecatedProperties = new ArrayList<>();
     private final List<JSONPointer> primaryIdentifier = new ArrayList<>();
     private final List<List<JSONPointer>> additionalIdentifiers = new ArrayList<>();
@@ -95,6 +96,11 @@ public class ResourceTypeSchema {
             ? Boolean.valueOf(this.unprocessedProperties.get("taggable").toString())
             : true;
         this.unprocessedProperties.remove("taggable");
+
+        this.unprocessedProperties.computeIfPresent("conditionallyCreateOnlyProperties", (k, v) -> {
+            ((ArrayList<?>) v).forEach(p -> this.conditionallyCreateOnlyProperties.add(new JSONPointer(p.toString())));
+            return null;
+        });
 
         this.unprocessedProperties.computeIfPresent("createOnlyProperties", (k, v) -> {
             ((ArrayList<?>) v).forEach(p -> this.createOnlyProperties.add(new JSONPointer(p.toString())));
@@ -157,6 +163,10 @@ public class ResourceTypeSchema {
 
     public String getDescription() {
         return schema.getDescription();
+    }
+
+    public List<String> getConditionallyCreateOnlyPropertiesAsStrings() throws ValidationException {
+        return this.conditionallyCreateOnlyProperties.stream().map(JSONPointer::toString).collect(Collectors.toList());
     }
 
     public List<String> getCreateOnlyPropertiesAsStrings() throws ValidationException {

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -387,8 +387,8 @@
             "description": "A list of JSON pointers to properties (typically sensitive) that are able to be specified by the customer but unable to be returned in a Read request",
             "$ref": "#/definitions/jsonPointerArray"
         },
-        "conditionallyCreateOnlyProperties": {
-            "description": "A list of JSON pointers to properties that are only able to cause replacement during the Update request.",
+        "conditionalCreateOnlyProperties": {
+            "description": "A list of JSON pointers for properties that can only be updated under certain conditions. For example, you can upgrade the engine version of an RDS DBInstance but you cannot downgrade it.  When updating this property for a resource in a CloudFormation stack, the resource will be replaced if it cannot be updated.",
             "$ref": "#/definitions/jsonPointerArray"
         },
         "createOnlyProperties": {

--- a/src/main/resources/schema/provider.definition.schema.v1.json
+++ b/src/main/resources/schema/provider.definition.schema.v1.json
@@ -387,6 +387,10 @@
             "description": "A list of JSON pointers to properties (typically sensitive) that are able to be specified by the customer but unable to be returned in a Read request",
             "$ref": "#/definitions/jsonPointerArray"
         },
+        "conditionallyCreateOnlyProperties": {
+            "description": "A list of JSON pointers to properties that are only able to cause replacement during the Update request.",
+            "$ref": "#/definitions/jsonPointerArray"
+        },
         "createOnlyProperties": {
             "description": "A list of JSON pointers to properties that are only able to be specified by the customer when creating a resource. Conversely, any property *not* in this list can be applied to an Update request.",
             "$ref": "#/definitions/jsonPointerArray"

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -52,6 +52,16 @@ public class ResourceTypeSchemaTest {
     }
 
     @Test
+    public void getConditionallyCreateOnlyProperties() {
+        JSONObject o = loadJSON(TEST_SCHEMA_PATH);
+        final ResourceTypeSchema schema = ResourceTypeSchema.load(o);
+
+        List<String> result = schema.getConditionallyCreateOnlyPropertiesAsStrings();
+
+        assertThat(result).containsExactly("/properties/propertyF");
+    }
+
+    @Test
     public void getCreateOnlyProperties() {
         JSONObject o = loadJSON(TEST_SCHEMA_PATH);
         final ResourceTypeSchema schema = ResourceTypeSchema.load(o);
@@ -171,6 +181,7 @@ public class ResourceTypeSchemaTest {
         assertThat(schema.getTypeName()).isEqualTo("AWS::Test::TestModel");
         assertThat(schema.getUnprocessedProperties()).isEmpty();
         assertThat(schema.getCreateOnlyPropertiesAsStrings()).isEmpty();
+        assertThat(schema.getConditionallyCreateOnlyPropertiesAsStrings()).isEmpty();
         assertThat(schema.getDeprecatedPropertiesAsStrings()).isEmpty();
         assertThat(schema.getPrimaryIdentifierAsStrings()).containsExactly("/properties/PropertyA");
         assertThat(schema.getAdditionalIdentifiersAsStrings()).isEmpty();

--- a/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/ResourceTypeSchemaTest.java
@@ -52,11 +52,11 @@ public class ResourceTypeSchemaTest {
     }
 
     @Test
-    public void getConditionallyCreateOnlyProperties() {
+    public void getConditionalCreateOnlyProperties() {
         JSONObject o = loadJSON(TEST_SCHEMA_PATH);
         final ResourceTypeSchema schema = ResourceTypeSchema.load(o);
 
-        List<String> result = schema.getConditionallyCreateOnlyPropertiesAsStrings();
+        List<String> result = schema.getConditionalCreateOnlyPropertiesAsStrings();
 
         assertThat(result).containsExactly("/properties/propertyF");
     }
@@ -181,7 +181,7 @@ public class ResourceTypeSchemaTest {
         assertThat(schema.getTypeName()).isEqualTo("AWS::Test::TestModel");
         assertThat(schema.getUnprocessedProperties()).isEmpty();
         assertThat(schema.getCreateOnlyPropertiesAsStrings()).isEmpty();
-        assertThat(schema.getConditionallyCreateOnlyPropertiesAsStrings()).isEmpty();
+        assertThat(schema.getConditionalCreateOnlyPropertiesAsStrings()).isEmpty();
         assertThat(schema.getDeprecatedPropertiesAsStrings()).isEmpty();
         assertThat(schema.getPrimaryIdentifierAsStrings()).containsExactly("/properties/PropertyA");
         assertThat(schema.getAdditionalIdentifiersAsStrings()).isEmpty();

--- a/src/test/resources/test-schema.json
+++ b/src/test/resources/test-schema.json
@@ -40,7 +40,7 @@
     "required": [
         "propertyB"
     ],
-    "conditionallyCreateOnlyProperties": [
+    "conditionalCreateOnlyProperties": [
         "/properties/propertyF"
     ],
     "createOnlyProperties": [

--- a/src/test/resources/test-schema.json
+++ b/src/test/resources/test-schema.json
@@ -28,6 +28,9 @@
                     "type": "string"
                 }
             }
+        },
+        "propertyF": {
+            "type": "string"
         }
     },
     "propertyTransform": {
@@ -36,6 +39,9 @@
     },
     "required": [
         "propertyB"
+    ],
+    "conditionallyCreateOnlyProperties": [
+        "/properties/propertyF"
     ],
     "createOnlyProperties": [
         "/properties/propertyA",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/issues/30

*Description of changes:*

Adding `conditionallyCreateOnlyProperties` to meta schema, so that resource providers could model properties that could not deterministically predict replacement/inline update

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
